### PR TITLE
Minor edit for Partners Articles on Homepage 

### DIFF
--- a/index.md
+++ b/index.md
@@ -45,4 +45,5 @@ sections:
       button: Click here to read more
       url: /partnersarticles/
       image: /images/IMG_7974.jpg
+      alt: Partner Articles
 ---

--- a/index.md
+++ b/index.md
@@ -40,11 +40,9 @@ sections:
       button: Find out more
   - infopic:
       title: Partner Articles
-      subtitle: Add an image and text
       id: infopic
       description: We curate relevant articles from our partner Institutions and Experts
       button: Click here to read more
       url: /partnersarticles/
       image: /images/IMG_7974.jpg
-      alt: Image alt text
 ---


### PR DESCRIPTION
Upon further inspection, I saw that the newly updated section on Partners Articles contained the subtitle text : add image and text. have deleted that. for review, please. Thank you! 