### PR TITLE
Changes to "ACICE - Events" and "Our Team"

### DIFF
--- a/pages/Events.md
+++ b/pages/Events.md
@@ -10,7 +10,7 @@ A list of our past and upcoming events can be found below:
 
 | Date | Meetings/Events | Venue |
 | -------- | -------- | -------- |
-|       |           |       |
+|    20-22 Jul 2026   |    4<sup>th</sup> Digital Defence Symposium       |    Raffles City Convention Centre   |
 
 #### Past <br>
 

--- a/pages/Events.md
+++ b/pages/Events.md
@@ -11,6 +11,9 @@ A list of our past and upcoming events can be found below:
 | Date | Meetings/Events | Venue |
 | -------- | -------- | -------- |
 |    20-22 Jul 2026   |    4<sup>th</sup> Digital Defence Symposium       |    Raffles City Convention Centre   |
+| 23 Jul 2026 | 4<sup>rd</sup> ASEAN Roundtable  | Raffles City Convention Centre |
+| 23 Jul 2026 | 5<sup>th</sup> Advisory Board Meeting |  Raffles City Convention Centre |
+| 22 Jul 2026 | 6<sup>th</sup> Experts Panel Meeting | Raffles City Convention Centre |
 
 #### Past <br>
 

--- a/pages/Events.md
+++ b/pages/Events.md
@@ -10,10 +10,10 @@ A list of our past and upcoming events can be found below:
 
 | Date | Meetings/Events | Venue |
 | -------- | -------- | -------- |
-|    20-22 Jul 2026   |    4<sup>th</sup> Digital Defence Symposium       |    Raffles City Convention Centre   |
 | 23 Jul 2026 | 4<sup>rd</sup> ASEAN Roundtable  | Raffles City Convention Centre |
 | 23 Jul 2026 | 5<sup>th</sup> Advisory Board Meeting |  Raffles City Convention Centre |
 | 22 Jul 2026 | 6<sup>th</sup> Experts Panel Meeting | Raffles City Convention Centre |
+|    20-22 Jul 2026   |    4<sup>th</sup> Digital Defence Symposium       |    Raffles City Convention Centre   |
 
 #### Past <br>
 

--- a/pages/Our Team.md
+++ b/pages/Our Team.md
@@ -12,16 +12,9 @@ Ms Yeo Seow Peng
 **Deputy Director**<br>
 Mr David Ooi Tian Rong <br>
 <br>
-**Assistant Director (Cybersecurity)** <br>
+**ACICE Team** <br>
 Ms Janie Leong Wai Fang<br>
-<br>
-**Analyst (Cybersecurity)**<br>
-Mr Tan Wei Ren<br>Mr Joel Chang Ri Jian
-<br>
-<br>
-**Analyst (Information)**<br>
-Mr Wong Ding Jie<br>Mr Jordon Sim Yong Zhi 
-<br>
-<br>
-**Senior Executive (Logistics and Operations)**
-<br>Mr Peter Koh
+Ms Lee Yin<br>
+Mr Joel Chang Ri Jian<br>
+Mr Wong Ding Jie<br>
+Mr Peter Koh


### PR DESCRIPTION
I have added the dates of the 4th DDS, Advisory Board Members, ASEAN Roundtable, and the Experts Panel Meeting under the "Events" Page. 

Besides, I have removed the headings by role for ACICE staff members, replacing them with "ACICE Team"